### PR TITLE
Fix parser module handling

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -11,6 +11,10 @@ Nova is engineered for *live* editing and incremental type‑checking.  Developi
 
 * **Fast imports** – no disk IO in the hot path.
 * **Open‑ended namespaces** – modules can grow new declarations at any time.
+  The `module` keyword is kept as a declaration purely for convenience.
+  Internally, the compiler works with blocks of declarations that are inserted
+  into the namespace pointed out by `module` (or the implicit namespace).
+  In the future this may become an explicit `namespace` keyword.
 * **Isolation of un‑committed edits** – a work‑in‑progress file should not break the public view until explicitly promoted.
 * **Hot reload** – evaluate expressions immediately after a change without restarting the VM.
 

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -63,7 +63,7 @@ defmodule Nova.Compiler.Parser do
           {:error, _} ->
             parse_any(
               [
-                &parse_module/1,
+                &parse_module_header/1,
                 &parse_import/1,
                 &parse_foreign_import_simple/1,
                 &parse_foreign_import/1,
@@ -83,6 +83,15 @@ defmodule Nova.Compiler.Parser do
   #  Module parsing
   # ------------------------------------------------------------
   def parse_module(tokens) do
+    with {:ok, module_ast, tokens} <- parse_module_header(tokens),
+         {:ok, decls, rest} <- parse_declarations(tokens),
+         :ok <- ensure_consumed(rest) do
+      {:ok, %{module_ast | declarations: decls}, []}
+    end
+  end
+
+  # Internal helper used when `module` appears as a declaration
+  defp parse_module_header(tokens) do
     tokens = drop_newlines(tokens)
 
     with {:ok, _, tokens} <- expect_keyword(tokens, "module"),


### PR DESCRIPTION
## Summary
- parse entire module via `parse_module` instead of just the header
- introduce `parse_module_header/1` and use it in declaration parser
- clarify that `module` is a convenience declaration, namespaces may change

## Testing
- `mix test` *(fails: command not found)*