### PR TITLE
Fix ImportDeclaration test struct field

### DIFF
--- a/test/parser_extensive.exs
+++ b/test/parser_extensive.exs
@@ -1395,7 +1395,7 @@ defmodule Nova.CompilerTest do
 
     expected_ast = %Ast.ImportDeclaration{
       module: %Nova.Compiler.Ast.Identifier{name: "Data.List"},
-      imports: []
+      items: []
     }
 
     assert_ast_match(ast, expected_ast)


### PR DESCRIPTION
## Summary
- update parser_extensive test to use `items` field for `ImportDeclaration`

## Testing
- `mix test` *(fails: `mix` command not found)*