### PR TITLE
Update test parser calls

### DIFF
--- a/test/inc1.exs
+++ b/test/inc1.exs
@@ -11,7 +11,7 @@ defmodule Nova.TypeChecker.IncrementalTest do
     assert rest == []
     IO.inspect(decls)
     IO.inspect(rest)
-    # {:ok, %Nova.Compiler.Ast.Module{body: decls}} = Parser.parse(tokens)
+    # {:ok, %Nova.Compiler.Ast.Module{body: decls}, []} = Parser.parse_module(tokens)
 
     # Start with empty type environment
     Enum.reduce(decls, Env.empty(), fn decl, env ->

--- a/test/parse_t1.exs
+++ b/test/parse_t1.exs
@@ -9,8 +9,9 @@ defmodule Nova.Compiler.RecordParserTest do
   defp parse!(src) do
     tokens = Tokenizer.tokenize(src)
 
-    case Parser.parse(tokens) do
-      {:ok, ast} -> ast
+    case Parser.parse_module(tokens) do
+      {:ok, ast, []} -> ast
+      {:ok, _ast, rest} -> flunk("unparsed tokens: #{inspect(rest)}")
       {:error, reason} -> flunk("parse failed: #{inspect(reason)}")
     end
   end

--- a/test/parser_extensive.exs
+++ b/test/parser_extensive.exs
@@ -8,7 +8,10 @@ defmodule Nova.CompilerTest do
   # Helper functions for testing
   defp tokenize_and_parse(source) do
     tokens = Tokenizer.tokenize(source)
-    Parser.parse(tokens)
+    case Parser.parse_expression(tokens) do
+      {:ok, ast, _rest} -> {:ok, ast}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp assert_tokens_match(source, expected_tokens) do

--- a/test/parser_extensive_2.exs
+++ b/test/parser_extensive_2.exs
@@ -8,7 +8,10 @@ defmodule Nova.CompilerTest do
   # Helper functions for testing
   defp tokenize_and_parse(source) do
     tokens = Tokenizer.tokenize(source)
-    Parser.parse(tokens)
+    case Parser.parse_expression(tokens) do
+      {:ok, ast, _rest} -> {:ok, ast}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp assert_tokens_match(source, expected_tokens) do

--- a/test/parser_record.exs
+++ b/test/parser_record.exs
@@ -10,9 +10,15 @@ defmodule Nova.Compiler.RecordParserTest do
   defp parse!(src) do
     tokens = Tokenizer.tokenize(src)
 
-    case Parser.parse(tokens) do
-      {:ok, ast} -> ast
-      {:error, reason} -> flunk("parser error: #{inspect(reason)}")
+    case Parser.parse_declarations(tokens) do
+      {:ok, [ast], []} -> ast
+      {:error, _} ->
+        case Parser.parse_expression(tokens) do
+          {:ok, ast, []} -> ast
+          {:ok, _ast, rest} -> flunk("unparsed tokens: #{inspect(rest)}")
+          {:error, reason} -> flunk("parser error: #{inspect(reason)}")
+        end
+      {:ok, _ast_list, rest} -> flunk("unparsed tokens: #{inspect(rest)}")
     end
   end
 


### PR DESCRIPTION
## Summary
- adapt tests to use `parse_module`, `parse_declarations`, and `parse_expression`
- update comment in incremental test

## Testing
- `mix test` *(fails: `mix` not found)*