### PR TITLE
Fix compile pattern env arg usage

### DIFF
--- a/lib/codegen.ex
+++ b/lib/codegen.ex
@@ -162,8 +162,8 @@ defmodule Nova.Compiler.CodeGen do
   end
 
   # Identifier
-  defp compile_expr(%Ast.Identifier{name: n}), do: sanitize_name(n)
-  defp compile_expr(%Ast.QualifiedIdentifier{namespace: ns, name: n}),
+  defp compile_expr(%Ast.Identifier{name: n}, _env), do: sanitize_name(n)
+  defp compile_expr(%Ast.QualifiedIdentifier{namespace: ns, name: n}, _env),
     do: "#{sanitize_name(ns)}.#{sanitize_name(n)}"
 
 
@@ -321,11 +321,11 @@ defmodule Nova.Compiler.CodeGen do
   # ─────────────────────────────────────────────────────────────
   # Patterns (env is only needed when they recurse into expressions)
   # ─────────────────────────────────────────────────────────────
-  defp compile_pattern(%Ast.Identifier{name: n}), do: sanitize_name(n)
-  defp compile_pattern(%Ast.QualifiedIdentifier{namespace: ns, name: n}),
+  defp compile_pattern(%Ast.Identifier{name: n}, _env), do: sanitize_name(n)
+  defp compile_pattern(%Ast.QualifiedIdentifier{namespace: ns, name: n}, _env),
     do: "#{sanitize_name(ns)}.#{sanitize_name(n)}"
-  defp compile_pattern(%Ast.Literal{} = lit), do: compile_expr(lit)
-  defp compile_pattern(%Nova.Compiler.Ast.Wildcard{}), do: "_"
+  defp compile_pattern(%Ast.Literal{} = lit, env), do: compile_expr(lit, env)
+  defp compile_pattern(%Nova.Compiler.Ast.Wildcard{}, _env), do: "_"
 
 
   defp compile_pattern(%Ast.Tuple{elements: es}, env),


### PR DESCRIPTION
## Summary
- handle env argument consistently in `CodeGen`

## Testing
- `mix format lib/codegen.ex` *(fails: `mix: command not found`)*